### PR TITLE
Improved the feeds extension

### DIFF
--- a/commanderbot/ext/feeds/feeds_cog.py
+++ b/commanderbot/ext/feeds/feeds_cog.py
@@ -115,7 +115,8 @@ class FeedsCog(Cog, name="commanderbot.ext.feeds"):
     @describe(
         channel="The channel to subscribe to a feed",
         feed="The feed to subscribe to",
-        notification_role="The role to ping when the feed is updated",
+        notification_role="The role to ping when the feed has new content",
+        auto_pin="Keep the latest message from this feed pinned",
     )
     async def cmd_feed_subscribe(
         self,
@@ -123,10 +124,11 @@ class FeedsCog(Cog, name="commanderbot.ext.feeds"):
         channel: MessageableGuildChannel,
         feed: FeedChoices,
         notification_role: Optional[Role],
+        auto_pin: Optional[bool],
     ):
         assert isinstance(interaction.guild, Guild)
         await self.state[interaction.guild].subscribe_to_feed(
-            interaction, channel, feed.value, notification_role
+            interaction, channel, feed.value, notification_role, auto_pin
         )
 
     # @@ feed modify
@@ -134,7 +136,8 @@ class FeedsCog(Cog, name="commanderbot.ext.feeds"):
     @describe(
         channel="The channel that was subscribed to a feed",
         feed="The feed that was subscribed to",
-        notification_role="The role to ping when the feed is updated",
+        notification_role="The role to ping when the feed has new content",
+        auto_pin="Keep the latest message from this feed pinned",
     )
     async def cmd_feed_modify(
         self,
@@ -142,10 +145,11 @@ class FeedsCog(Cog, name="commanderbot.ext.feeds"):
         channel: MessageableGuildChannel,
         feed: FeedChoices,
         notification_role: Optional[Role],
+        auto_pin: Optional[bool],
     ):
         assert isinstance(interaction.guild, Guild)
         await self.state[interaction.guild].modify_subscription(
-            interaction, channel, feed.value, notification_role
+            interaction, channel, feed.value, notification_role, auto_pin
         )
 
     # @@ feed unsubscribe

--- a/commanderbot/ext/feeds/feeds_state.py
+++ b/commanderbot/ext/feeds/feeds_state.py
@@ -118,10 +118,6 @@ class FeedsState(GuildPartitionedCogState[FeedsGuildState]):
             view.add_item(
                 ui.Button(label="Changelog (Mirror)", url=update_info.mirror_url)
             )
-        view.add_item(ui.Button(label="Jira", url="https://bugs.mojang.com/"))
-        view.add_item(
-            ui.Button(label="Feedback", url="https://feedback.minecraft.net/")
-        )
         return view
 
     def _create_mcbe_update_buttons(
@@ -129,10 +125,6 @@ class FeedsState(GuildPartitionedCogState[FeedsGuildState]):
     ) -> ui.View:
         view = ui.View()
         view.add_item(ui.Button(label="Changelog", url=update_info.url))
-        view.add_item(ui.Button(label="Jira", url="https://bugs.mojang.com/"))
-        view.add_item(
-            ui.Button(label="Feedback", url="https://feedback.minecraft.net/")
-        )
         return view
 
     def _create_mcje_jar_update_buttons(

--- a/commanderbot/ext/feeds/feeds_state.py
+++ b/commanderbot/ext/feeds/feeds_state.py
@@ -109,8 +109,23 @@ class FeedsState(GuildPartitionedCogState[FeedsGuildState]):
             except:
                 pass
 
-    def _create_mc_update_buttons(
-        self, update_info: MinecraftJavaUpdateInfo | MinecraftBedrockUpdateInfo
+    def _create_mcje_update_buttons(
+        self, update_info: MinecraftJavaUpdateInfo
+    ) -> ui.View:
+        view = ui.View()
+        view.add_item(ui.Button(label="Changelog", url=update_info.url))
+        if update_info.mirror_url:
+            view.add_item(
+                ui.Button(label="Changelog (Mirror)", url=update_info.mirror_url)
+            )
+        view.add_item(ui.Button(label="Jira", url="https://bugs.mojang.com/"))
+        view.add_item(
+            ui.Button(label="Feedback", url="https://feedback.minecraft.net/")
+        )
+        return view
+
+    def _create_mcbe_update_buttons(
+        self, update_info: MinecraftBedrockUpdateInfo
     ) -> ui.View:
         view = ui.View()
         view.add_item(ui.Button(label="Changelog", url=update_info.url))
@@ -120,7 +135,7 @@ class FeedsState(GuildPartitionedCogState[FeedsGuildState]):
         )
         return view
 
-    def _create_mc_jar_update_buttons(
+    def _create_mcje_jar_update_buttons(
         self, update_info: MinecraftJavaJarUpdateInfo
     ) -> ui.View:
         view = ui.View()
@@ -149,7 +164,7 @@ class FeedsState(GuildPartitionedCogState[FeedsGuildState]):
         await self._send_to_subscribers(
             FeedType.MINECRAFT_JAVA_RELEASES,
             embed,
-            self._create_mc_update_buttons(update_info),
+            self._create_mcje_update_buttons(update_info),
             f"Minecraft: Java Edition {update_info.version} has been released! 🎉",
         )
 
@@ -172,7 +187,7 @@ class FeedsState(GuildPartitionedCogState[FeedsGuildState]):
         await self._send_to_subscribers(
             FeedType.MINECRAFT_JAVA_SNAPSHOTS,
             embed,
-            self._create_mc_update_buttons(update_info),
+            self._create_mcje_update_buttons(update_info),
             f"Minecraft: Java Edition {update_info.version} has been released! 📸",
         )
 
@@ -195,8 +210,8 @@ class FeedsState(GuildPartitionedCogState[FeedsGuildState]):
         await self._send_to_subscribers(
             FeedType.MINECRAFT_BEDROCK_RELEASES,
             embed,
-            self._create_mc_update_buttons(update_info),
-            f"Minecraft: Bedrock Edition {update_info.version} has been released! 🎉",
+            self._create_mcbe_update_buttons(update_info),
+            f"Minecraft: Bedrock Edition {update_info.version} has been released! 🍊",
         )
 
     # @@ Minecraft: Bedrock Edition Previews
@@ -218,11 +233,11 @@ class FeedsState(GuildPartitionedCogState[FeedsGuildState]):
         await self._send_to_subscribers(
             FeedType.MINECRAFT_BEDROCK_PREVIEWS,
             embed,
-            self._create_mc_update_buttons(update_info),
+            self._create_mcbe_update_buttons(update_info),
             f"Minecraft: Bedrock Edition {update_info.version} has been released! 🍌",
         )
 
-    # @@ Minecraft: Java Edition Release JARs
+    # @@ Minecraft: Java Edition Release Jars
     async def _on_mcje_release_jar(self, jar_update_info: MinecraftJavaJarUpdateInfo):
         embed = Embed(
             title=f"Minecraft: Java Edition {jar_update_info.version}",
@@ -251,11 +266,11 @@ class FeedsState(GuildPartitionedCogState[FeedsGuildState]):
         await self._send_to_subscribers(
             FeedType.MINECRAFT_JAVA_RELEASE_JARS,
             embed,
-            self._create_mc_jar_update_buttons(jar_update_info),
+            self._create_mcje_jar_update_buttons(jar_update_info),
             f"A jar has been released for Minecraft: Java Edition {jar_update_info.version}! 🎉",
         )
 
-    # @@ Minecraft: Java Edition Snapshot JARs
+    # @@ Minecraft: Java Edition Snapshot Jars
     async def _on_mcje_snapshot_jar(self, jar_update_info: MinecraftJavaJarUpdateInfo):
         embed = Embed(
             title=f"Minecraft: Java Edition {jar_update_info.version}",
@@ -284,7 +299,7 @@ class FeedsState(GuildPartitionedCogState[FeedsGuildState]):
         await self._send_to_subscribers(
             FeedType.MINECRAFT_JAVA_SNAPSHOT_JARS,
             embed,
-            self._create_mc_jar_update_buttons(jar_update_info),
+            self._create_mcje_jar_update_buttons(jar_update_info),
             f"A jar has been released for Minecraft: Java Edition {jar_update_info.version}! 📸",
         )
 
@@ -316,7 +331,7 @@ class FeedsState(GuildPartitionedCogState[FeedsGuildState]):
         embed.add_field(name="Previous Status Code", value=formatted_prev_status_code)
         embed.add_field(
             name="Cached Items",
-            value=f"`{provider.cached_items}/{provider.cache_size}`",
+            value=f"`{provider.cached_items}`",
         )
         embed.set_thumbnail(url=options.icon_url)
 

--- a/commanderbot/ext/feeds/feeds_store.py
+++ b/commanderbot/ext/feeds/feeds_store.py
@@ -2,12 +2,14 @@ from datetime import datetime
 from typing import AsyncIterable, Optional, Protocol
 
 from commanderbot.ext.feeds.providers import FeedType
-from commanderbot.lib import ChannelID, RoleID, UserID
+from commanderbot.lib import ChannelID, MessageID, RoleID, UserID
 
 
 class FeedsSubscription(Protocol):
     channel_id: ChannelID
     notification_role_id: Optional[RoleID]
+    auto_pin: bool
+    current_pin_id: Optional[MessageID]
     subscriber_id: UserID
     subscribed_on: datetime
 
@@ -18,6 +20,7 @@ class FeedsStore(Protocol):
         channel_id: ChannelID,
         feed: FeedType,
         notification_role_id: Optional[RoleID],
+        auto_pin: bool,
         user_id: UserID,
     ) -> FeedsSubscription: ...
 
@@ -26,7 +29,12 @@ class FeedsStore(Protocol):
         channel_id: ChannelID,
         feed: FeedType,
         notification_role_id: Optional[RoleID],
+        auto_pin: bool,
     ) -> FeedsSubscription: ...
+
+    async def update_current_pin(
+        self, subscription: FeedsSubscription, pin_id: MessageID
+    ): ...
 
     async def unsubscribe(
         self, channel_id: ChannelID, feed: FeedType

--- a/commanderbot/ext/feeds/providers/minecraft_java_jar_updates.py
+++ b/commanderbot/ext/feeds/providers/minecraft_java_jar_updates.py
@@ -151,4 +151,3 @@ class MinecraftJavaJarUpdates(FeedProviderBase[MinecraftJavaJarUpdatesOptions, s
                 await self.release_handler(jar_update_info)
             elif version.is_snapshot and self.snapshot_handler:
                 await self.snapshot_handler(jar_update_info)
-            break

--- a/commanderbot/ext/feeds/providers/minecraft_java_jar_updates.py
+++ b/commanderbot/ext/feeds/providers/minecraft_java_jar_updates.py
@@ -113,7 +113,7 @@ class MinecraftJavaJarUpdates(FeedProviderBase[MinecraftJavaJarUpdatesOptions, s
 
         return new_versions
 
-    @tasks.loop(minutes=5)
+    @tasks.loop(minutes=2)
     async def _on_poll(self):
         # Populate the cache on the first time we poll and immediately return
         if not self.prev_status_code:
@@ -151,3 +151,4 @@ class MinecraftJavaJarUpdates(FeedProviderBase[MinecraftJavaJarUpdatesOptions, s
                 await self.release_handler(jar_update_info)
             elif version.is_snapshot and self.snapshot_handler:
                 await self.snapshot_handler(jar_update_info)
+            break

--- a/commanderbot/ext/feeds/providers/minecraft_java_jar_updates.py
+++ b/commanderbot/ext/feeds/providers/minecraft_java_jar_updates.py
@@ -8,6 +8,7 @@ from discord.utils import utcnow
 
 from commanderbot.lib import USER_AGENT, JsonObject
 
+from .exceptions import MissingFeedHandler
 from .feed_provider_base import FeedProviderBase, FeedProviderOptionsBase
 from .utils import FeedHandler, MinecraftJavaVersion
 
@@ -151,3 +152,5 @@ class MinecraftJavaJarUpdates(FeedProviderBase[MinecraftJavaJarUpdatesOptions, s
                 await self.release_handler(jar_update_info)
             elif version.is_snapshot and self.snapshot_handler:
                 await self.snapshot_handler(jar_update_info)
+            else:
+                raise MissingFeedHandler

--- a/commanderbot/ext/feeds/providers/minecraft_java_jar_updates.py
+++ b/commanderbot/ext/feeds/providers/minecraft_java_jar_updates.py
@@ -17,8 +17,6 @@ __all__ = (
     "MinecraftJavaJarUpdates",
 )
 
-CACHE_SIZE: int = 50
-
 
 @dataclass
 class MinecraftJavaJarUpdateInfo:
@@ -37,8 +35,6 @@ class MinecraftJavaJarUpdatesOptions(FeedProviderOptionsBase):
     release_jar_icon_url: str
     snapshot_jar_icon_url: str
 
-    cache_size: int = CACHE_SIZE
-
     # @overrides FromDataMixin
     @classmethod
     def try_from_data(cls, data: Any) -> Optional[Self]:
@@ -48,23 +44,13 @@ class MinecraftJavaJarUpdatesOptions(FeedProviderOptionsBase):
                 icon_url=data["icon_url"],
                 release_jar_icon_url=data["release_jar_icon_url"],
                 snapshot_jar_icon_url=data["snapshot_jar_icon_url"],
-                cache_size=data.get("cache_size", CACHE_SIZE),
             )
 
 
 @dataclass
 class MinecraftJavaJarUpdates(FeedProviderBase[MinecraftJavaJarUpdatesOptions, str]):
-    def __init__(
-        self,
-        url: str,
-        *,
-        cache_size: int = CACHE_SIZE,
-    ):
-        super().__init__(
-            url=url,
-            logger_name="feeds.minecraft_java_jar_updates",
-            cache_size=cache_size,
-        )
+    def __init__(self, url: str):
+        super().__init__(url=url, logger_name="feeds.minecraft_java_jar_updates")
 
         self.release_handler: Optional[FeedHandler[MinecraftJavaJarUpdateInfo]] = None
         self.snapshot_handler: Optional[FeedHandler[MinecraftJavaJarUpdateInfo]] = None
@@ -73,19 +59,7 @@ class MinecraftJavaJarUpdates(FeedProviderBase[MinecraftJavaJarUpdatesOptions, s
 
     @classmethod
     def from_options(cls, options: MinecraftJavaJarUpdatesOptions) -> Self:
-        return cls(url=options.url, cache_size=options.cache_size)
-
-    def start(self):
-        self._log.info("Started polling for updates...")
-        self._poll_for_updates.start()
-
-    def stop(self):
-        self._log.info("Stopped polling for updates")
-        self._poll_for_updates.stop()
-
-    def restart(self):
-        self._log.info("Restarting...")
-        self._poll_for_updates.restart()
+        return cls(url=options.url)
 
     async def _fetch_version(
         self, session: aiohttp.ClientSession, url: str
@@ -133,14 +107,14 @@ class MinecraftJavaJarUpdates(FeedProviderBase[MinecraftJavaJarUpdatesOptions, s
                         continue
 
                     # This is a new version, so cache it and request the rest of its data
-                    self._cache.append(id)
+                    self._cache.add(id)
                     if version := await self._fetch_version(session, url):
                         new_versions.append(version)
 
         return new_versions
 
     @tasks.loop(minutes=5)
-    async def _poll_for_updates(self):
+    async def _on_poll(self):
         # Populate the cache on the first time we poll and immediately return
         if not self.prev_status_code:
             self._log.info("Building version cache...")
@@ -156,13 +130,11 @@ class MinecraftJavaJarUpdates(FeedProviderBase[MinecraftJavaJarUpdatesOptions, s
         self._log.debug(f"Found {len(new_versions)} new versions")
 
         self.prev_request_date = utcnow()
-        self.next_request_date = self._poll_for_updates.next_iteration
+        self.next_request_date = self._on_poll.next_iteration
 
         # Process latest versions
         for version in new_versions:
             # Create jar update info
-            is_release: bool = version.type == "release"
-            is_snapshot: bool = version.type == "snapshot"
             jar_update_info = MinecraftJavaJarUpdateInfo(
                 version=version.id,
                 released=version.release_time,
@@ -175,7 +147,7 @@ class MinecraftJavaJarUpdates(FeedProviderBase[MinecraftJavaJarUpdatesOptions, s
             )
 
             # Send jar update to the handlers
-            if is_release and self.release_handler:
+            if version.is_release and self.release_handler:
                 await self.release_handler(jar_update_info)
-            elif is_snapshot and self.snapshot_handler:
+            elif version.is_snapshot and self.snapshot_handler:
                 await self.snapshot_handler(jar_update_info)

--- a/commanderbot/ext/feeds/providers/minecraft_java_updates.py
+++ b/commanderbot/ext/feeds/providers/minecraft_java_updates.py
@@ -104,7 +104,7 @@ class MinecraftJavaUpdates(FeedProviderBase[MinecraftJavaUpdatesOptions, str]):
 
         return new_changelogs
 
-    @tasks.loop(minutes=5)
+    @tasks.loop(minutes=2)
     async def _on_poll(self):
         # Populate the cache on the first time we poll and immediately return
         if not self.prev_status_code:
@@ -130,14 +130,8 @@ class MinecraftJavaUpdates(FeedProviderBase[MinecraftJavaUpdatesOptions, str]):
                 title=changelog.title,
                 description=changelog.short_text,
                 published=changelog.date,
-                url=self._primary_changelog_viewer_url.format(
-                    version=changelog.version
-                ),
-                mirror_url=(
-                    self._mirror_changelog_viewer_url.format(version=changelog.version)
-                    if self._mirror_changelog_viewer_url
-                    else None
-                ),
+                url=self._get_primary_url(changelog),
+                mirror_url=self._get_mirror_url(changelog),
                 version=changelog.version,
                 thumbnail_url=(self.base_url + changelog.image_url),
             )
@@ -149,3 +143,10 @@ class MinecraftJavaUpdates(FeedProviderBase[MinecraftJavaUpdatesOptions, str]):
                 await self.snapshot_handler(update_info)
             else:
                 raise MissingFeedHandler
+
+    def _get_primary_url(self, changelog: MinecraftJavaChangelog) -> str:
+        return self._primary_changelog_viewer_url.format(version=changelog.version)
+
+    def _get_mirror_url(self, changelog: MinecraftJavaChangelog) -> Optional[str]:
+        if self._mirror_changelog_viewer_url:
+            return self._mirror_changelog_viewer_url.format(version=changelog.version)

--- a/commanderbot/ext/feeds/providers/minecraft_java_updates.py
+++ b/commanderbot/ext/feeds/providers/minecraft_java_updates.py
@@ -1,35 +1,22 @@
-import re
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional, Self
-from urllib.parse import urlparse, urlunparse
 
 import aiohttp
-import feedparser
 from discord.ext import tasks
 from discord.utils import utcnow
 
 from commanderbot.lib import USER_AGENT
+from commanderbot.lib.types import JsonObject
 
-from .exceptions import MissingFeedHandler, UnknownMinecraftVersionFormat
+from .exceptions import MissingFeedHandler
 from .feed_provider_base import FeedProviderBase, FeedProviderOptionsBase
-from .utils import FeedHandler, RSSFeedItem
+from .utils import FeedHandler, MinecraftJavaChangelog
 
 __all__ = (
     "MinecraftJavaUpdateInfo",
     "MinecraftJavaUpdatesOptions",
     "MinecraftJavaUpdates",
-)
-
-CACHE_SIZE: int = 100
-
-RELEASE_VERSION_PATTERN = re.compile(r"\d+\.\d+(?:\.\d+)?")
-SNAPSHOT_VERSION_PATTERN = re.compile(r"\d\dw\d\d[a-z]")
-PRE_RELEASE_VERSION_PATTERN = re.compile(
-    r"\d+\.\d+(?:\.\d+)?[_\-\s]pre[_\-\s]release[_\-\s]\d+", flags=re.IGNORECASE
-)
-JAVA_RELEASE_CANDIDATE_VERSION_PATTERN = re.compile(
-    r"\d+\.\d+(?:\.\d+)?[_\-\s]release[_\-\s]candidate[_\-\s]\d+", flags=re.IGNORECASE
 )
 
 
@@ -40,28 +27,29 @@ class MinecraftJavaUpdateInfo:
     published: datetime
     url: str
     version: str
-    thumbnail_url: Optional[str] = None
+    thumbnail_url: str
+    mirror_url: Optional[str] = None
 
 
 @dataclass
 class MinecraftJavaUpdatesOptions(FeedProviderOptionsBase):
     release_icon_url: str
     snapshot_icon_url: str
-
-    image_proxy: Optional[str] = None
-    cache_size: int = CACHE_SIZE
+    primary_changelog_viewer_url: str
+    mirror_changelog_viewer_url: Optional[str]
 
     # @overrides FromDataMixin
     @classmethod
     def try_from_data(cls, data: Any) -> Optional[Self]:
         if isinstance(data, dict):
+            raw_changelog_viewer: dict = data["changelog_viewer"]
             return cls(
                 url=data["url"],
                 icon_url=data["icon_url"],
                 release_icon_url=data["release_icon_url"],
                 snapshot_icon_url=data["snapshot_icon_url"],
-                image_proxy=data.get("image_proxy"),
-                cache_size=data.get("cache_size", CACHE_SIZE),
+                primary_changelog_viewer_url=raw_changelog_viewer["primary_url"],
+                mirror_changelog_viewer_url=raw_changelog_viewer.get("mirror_url"),
             )
 
 
@@ -69,162 +57,95 @@ class MinecraftJavaUpdates(FeedProviderBase[MinecraftJavaUpdatesOptions, str]):
     def __init__(
         self,
         url: str,
-        *,
-        image_proxy: Optional[str] = None,
-        cache_size: int = CACHE_SIZE,
+        primary_changelog_viewer_url: str,
+        mirror_changelog_viewer_url: Optional[str] = None,
     ):
-        super().__init__(
-            url=url,
-            logger_name="feeds.minecraft_java_updates",
-            cache_size=cache_size,
-        )
+        super().__init__(url=url, logger_name="feeds.minecraft_java_updates")
+        self._primary_changelog_viewer_url: str = primary_changelog_viewer_url
+        self._mirror_changelog_viewer_url: Optional[str] = mirror_changelog_viewer_url
 
         self.release_handler: Optional[FeedHandler[MinecraftJavaUpdateInfo]] = None
         self.snapshot_handler: Optional[FeedHandler[MinecraftJavaUpdateInfo]] = None
 
-        self._etag: Optional[str] = None
         self._last_modified: Optional[str] = None
-        self._image_proxy: Optional[str] = image_proxy
 
     @classmethod
     def from_options(cls, options: MinecraftJavaUpdatesOptions) -> Self:
         return cls(
             url=options.url,
-            image_proxy=options.image_proxy,
-            cache_size=options.cache_size,
+            primary_changelog_viewer_url=options.primary_changelog_viewer_url,
+            mirror_changelog_viewer_url=options.mirror_changelog_viewer_url,
         )
 
-    def start(self):
-        self._log.info("Started polling for updates...")
-        self._poll_for_updates.start()
-
-    def stop(self):
-        self._log.info("Stopped polling for updates")
-        self._poll_for_updates.stop()
-
-    def restart(self):
-        self._log.info("Restarting...")
-        self._poll_for_updates.restart()
-
-    async def _fetch_latest_articles(self) -> list[RSSFeedItem]:
-        new_articles = []
-        async with aiohttp.ClientSession(
-            headers={"User-Agent": USER_AGENT}, cookies={"AKA_A2": "A"}
-        ) as session:
+    async def _fetch_latest_changelogs(self) -> list[MinecraftJavaChangelog]:
+        new_changelogs = []
+        async with aiohttp.ClientSession(headers={"User-Agent": USER_AGENT}) as session:
             async with session.get(
-                self.url,
-                headers={
-                    "If-None-Match": self._etag or "",
-                    "If-Modified-Since": self._last_modified or "",
-                    "Accept-Language": "*",
-                },
+                self.url, headers={"If-Modified-Since": self._last_modified or ""}
             ) as response:
                 # Store the status code and other response header data
                 self.prev_status_code = response.status
-                self._etag = response.headers.get("ETag")
                 self._last_modified = response.headers.get("Last-Modified")
 
                 # Return early if we didn't get an `OK` response
                 if self.prev_status_code != 200:
                     return []
 
-                # Parse the RSS feed
-                raw_rss_feed: str = await response.text()
-                rss_feed = feedparser.parse(raw_rss_feed)
-
-                # Add any new articles to the cache and the returned array
-                article_gen = (
-                    RSSFeedItem.from_data(raw_article)
-                    for raw_article in rss_feed.get("entries", [])
+                # Add any new changelogs to the cache and the returned array
+                changelogs: JsonObject = await response.json()
+                changelog_gen = (
+                    MinecraftJavaChangelog.from_data(raw_changelog)
+                    for raw_changelog in changelogs.get("entries", [])
                 )
-                for article in article_gen:
-                    if article.id and article.id not in self._cache:
-                        self._cache.append(article.id)
-                        new_articles.append(article)
+                for changelog in changelog_gen:
+                    if changelog.id not in self._cache:
+                        self._cache.add(changelog.id)
+                        new_changelogs.append(changelog)
 
-        return new_articles
+        return new_changelogs
 
     @tasks.loop(minutes=5)
-    async def _poll_for_updates(self):
+    async def _on_poll(self):
         # Populate the cache on the first time we poll and immediately return
         if not self.prev_status_code:
-            self._log.info("Building article cache...")
-            await self._fetch_latest_articles()
+            self._log.info("Building changelog cache...")
+            await self._fetch_latest_changelogs()
             self._log.info(
-                f"Done building article cache (Initial size: {len(self._cache)})"
+                f"Done building changelog cache (Initial size: {len(self._cache)})"
             )
             return
 
-        # Try to get the latest articles
-        self._log.debug("Polling for new articles...")
-        new_articles = await self._fetch_latest_articles()
-        self._log.debug(f"Found {len(new_articles)} new articles")
+        # Try to get the latest changelogs
+        self._log.debug("Polling for new changelogs...")
+        new_changelogs = await self._fetch_latest_changelogs()
+        self._log.debug(f"Found {len(new_changelogs)} new changelogs")
 
         self.prev_request_date = utcnow()
-        self.next_request_date = self._poll_for_updates.next_iteration
+        self.next_request_date = self._on_poll.next_iteration
 
-        # Process articles
-        for article in new_articles:
-            # Skip article if it doesn't have `primary_tag` or it's not news
-            if not article.primary_tag or article.primary_tag.lower() != "news":
-                self._log.debug(f"Skipping article: {article.title}")
-                continue
-
-            # Skip article if it isn't for Java
-            if not self._is_java_update_article(article):
-                self._log.debug(f"Skipping article: {article.title}")
-                continue
-
+        # Process changelogs
+        for changelog in new_changelogs:
             # Create update info
-            version, is_snapshot = self._get_version(article)
             update_info = MinecraftJavaUpdateInfo(
-                title=article.title,
-                description=article.description,
-                published=article.published,
-                url=article.link,
-                version=version,
-                thumbnail_url=self._get_thumbnail(article),
+                title=changelog.title,
+                description=changelog.short_text,
+                published=changelog.date,
+                url=self._primary_changelog_viewer_url.format(
+                    version=changelog.version
+                ),
+                mirror_url=(
+                    self._mirror_changelog_viewer_url.format(version=changelog.version)
+                    if self._mirror_changelog_viewer_url
+                    else None
+                ),
+                version=changelog.version,
+                thumbnail_url=(self.base_url + changelog.image_url),
             )
 
             # Send update to the handlers
-            if not is_snapshot and self.release_handler:
+            if changelog.is_release and self.release_handler:
                 await self.release_handler(update_info)
-            elif is_snapshot and self.snapshot_handler:
+            elif changelog.is_snapshot and self.snapshot_handler:
                 await self.snapshot_handler(update_info)
             else:
                 raise MissingFeedHandler
-
-    def _is_java_update_article(self, article: RSSFeedItem) -> bool:
-        query = f"{article.title} {article.description} {article.link}".lower()
-
-        # `java` must exist
-        if "java" not in query:
-            return False
-
-        # Check for words related to Bedrock or Realms
-        if "beta" in query or "preview" in query or "realms" in query:
-            return False
-
-        # Must have a combination of `java` and `snapshot|release|candidate`
-        return "snapshot" in query or "release" in query or "candidate" in query
-
-    def _get_version(self, article: RSSFeedItem) -> tuple[str, bool]:
-        query = f"{article.title} {article.description} {article.link}"
-        if match := SNAPSHOT_VERSION_PATTERN.search(query):
-            return (match.group(0), True)
-        elif match := PRE_RELEASE_VERSION_PATTERN.search(query):
-            return (match.group(0), True)
-        elif match := JAVA_RELEASE_CANDIDATE_VERSION_PATTERN.search(query):
-            return (match.group(0), True)
-        elif match := RELEASE_VERSION_PATTERN.search(query):
-            return (match.group(0), False)
-        raise UnknownMinecraftVersionFormat(query)
-
-    def _get_thumbnail(self, article: RSSFeedItem) -> Optional[str]:
-        if article.image_url:
-            url_parts = urlparse(article.link)
-            url_parts = url_parts._replace(path=article.image_url)
-            thumbnail_url = urlunparse(url_parts).replace(" ", "%20")
-            if self._image_proxy:
-                return self._image_proxy.format(url=thumbnail_url)
-            return thumbnail_url

--- a/commanderbot/lib/types.py
+++ b/commanderbot/lib/types.py
@@ -20,6 +20,7 @@ __all__ = (
     "IDType",
     "GuildID",
     "ChannelID",
+    "MessageID",
     "RoleID",
     "UserID",
     "ForumTagID",
@@ -42,6 +43,7 @@ IDType: TypeAlias = int
 
 GuildID: TypeAlias = IDType
 ChannelID: TypeAlias = IDType
+MessageID: TypeAlias = IDType
 RoleID: TypeAlias = IDType
 UserID: TypeAlias = IDType
 ForumTagID: TypeAlias = IDType

--- a/poetry.lock
+++ b/poetry.lock
@@ -264,31 +264,17 @@ voice = ["PyNaCl (>=1.3.0,<1.6)"]
 
 [[package]]
 name = "emoji"
-version = "2.11.0"
+version = "2.11.1"
 description = "Emoji for Python"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 files = [
-    {file = "emoji-2.11.0-py2.py3-none-any.whl", hash = "sha256:63fc9107f06c6c2e48e5078ce9575cef98518f5ac09474f6148a43e989989582"},
-    {file = "emoji-2.11.0.tar.gz", hash = "sha256:772eaa30f4e0b1ce95148a092df4c7dc97644532c03225326b0fd05e8a9f72a3"},
+    {file = "emoji-2.11.1-py2.py3-none-any.whl", hash = "sha256:b7ba25299bbf520cc8727848ae66b986da32aee27dc2887eaea2bff07226ce49"},
+    {file = "emoji-2.11.1.tar.gz", hash = "sha256:062ff0b3154b6219143f8b9f4b3e5c64c35bc2b146e6e2349ab5f29e218ce1ee"},
 ]
 
 [package.extras]
 dev = ["coverage", "coveralls", "pytest"]
-
-[[package]]
-name = "feedparser"
-version = "6.0.11"
-description = "Universal feed parser, handles RSS 0.9x, RSS 1.0, RSS 2.0, CDF, Atom 0.3, and Atom 1.0 feeds"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "feedparser-6.0.11-py3-none-any.whl", hash = "sha256:0be7ee7b395572b19ebeb1d6aafb0028dee11169f1c934e0ed67d54992f4ad45"},
-    {file = "feedparser-6.0.11.tar.gz", hash = "sha256:c9d0407b64c6f2a065d0ebb292c2b35c01050cc0dc33757461aaabdc4c4184d5"},
-]
-
-[package.dependencies]
-sgmllib3k = "*"
 
 [[package]]
 name = "frozenlist"
@@ -631,18 +617,19 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.2.0"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+version = "4.2.1"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.2.0-py3-none-any.whl", hash = "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068"},
-    {file = "platformdirs-4.2.0.tar.gz", hash = "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"},
+    {file = "platformdirs-4.2.1-py3-none-any.whl", hash = "sha256:17d5a1161b3fd67b390023cb2d3b026bbd40abde6fdb052dfbd3a29c3ba22ee1"},
+    {file = "platformdirs-4.2.1.tar.gz", hash = "sha256:031cd18d4ec63ec53e82dceaac0417d218a6863f7745dfcc9efe7793b7039bdf"},
 ]
 
 [package.extras]
 docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
+type = ["mypy (>=1.8)"]
 
 [[package]]
 name = "ply"
@@ -744,16 +731,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
-]
-
-[[package]]
-name = "sgmllib3k"
-version = "1.0.0"
-description = "Py3k port of sgmllib."
-optional = false
-python-versions = "*"
-files = [
-    {file = "sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9"},
 ]
 
 [[package]]
@@ -946,4 +923,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "303dacab438dabf960e8e9bf8533c912e2d7de9b05121dec0893122cddb9e852"
+content-hash = "11ee6bffa31060ed4ec2a535ef3237de368d69e05ed4fa8b83286bb5c3becd5e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "commanderbot"
-version = "0.20.0a23"
+version = "0.20.0a24"
 description = "A collection of utilities and extensions for discord.py bots."
 authors = ["Arcensoth <arcensoth@gmail.com>"]
 license = "MIT"
@@ -36,7 +36,6 @@ emoji = "^2.0.0"
 allay = "^1.3.0"
 mccq = "^1.0.2"
 psutil = "^5.9.0"
-feedparser = "^6.0.11"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.0.0"


### PR DESCRIPTION
- Java changelogs now use the launcher's changelog feed
  - Embed links will now link to a changelog viewer instead of minecraft.net
- Added support for auto pinning the latest feed message
- Improved the feed provider logic