### PR TITLE
Fix jira command after migration

### DIFF
--- a/commanderbot/ext/jira/jira_client.py
+++ b/commanderbot/ext/jira/jira_client.py
@@ -84,6 +84,7 @@ class JiraClient:
         return JiraIssue(
             issue_id=issue_id,
             url=f"{base_url}/browse/{issue_id}",
+            icon_url=f"{base_url}/{issue_id.split("-")[0].lower()}_icon.png",
             summary=fields["summary"],
             assignee=assignee,
             created=datetime.strptime(fields["created"], "%Y-%m-%dT%H:%M:%S.%f%z"),

--- a/commanderbot/ext/jira/jira_cog.py
+++ b/commanderbot/ext/jira/jira_cog.py
@@ -87,8 +87,6 @@ class JiraCog(Cog, name="commanderbot.ext.jira"):
             color=issue.status_color.value,
         )
 
-        issue_embed.set_thumbnail(url=issue.icon_url)
-
         for k, v in issue.fields.items():
             issue_embed.add_field(name=k, value=v)
 

--- a/commanderbot/ext/jira/jira_cog.py
+++ b/commanderbot/ext/jira/jira_cog.py
@@ -87,6 +87,8 @@ class JiraCog(Cog, name="commanderbot.ext.jira"):
             color=issue.status_color.value,
         )
 
+        issue_embed.set_thumbnail(url=issue.icon_url)
+
         for k, v in issue.fields.items():
             issue_embed.add_field(name=k, value=v)
 

--- a/commanderbot/ext/jira/jira_issue.py
+++ b/commanderbot/ext/jira/jira_issue.py
@@ -37,6 +37,7 @@ class StatusColor(Enum):
 class JiraIssue:
     issue_id: str
     url: str
+    icon_url: str
     summary: str
     assignee: str
     created: datetime

--- a/commanderbot/ext/jira/jira_issue.py
+++ b/commanderbot/ext/jira/jira_issue.py
@@ -37,9 +37,7 @@ class StatusColor(Enum):
 class JiraIssue:
     issue_id: str
     url: str
-    icon_url: str
     summary: str
-    reporter: str
     assignee: str
     created: datetime
     updated: datetime
@@ -53,7 +51,6 @@ class JiraIssue:
     @property
     def fields(self) -> dict:
         return {
-            "Reported By": self.reporter,
             "Assigned To": self.assignee,
             "Created": format_dt(self.created, style="R"),
             "Updated": format_dt(self.updated, style="R"),


### PR DESCRIPTION
Proof of concept of the new bugs.mojang.com integration, using the public facing `https://bugs.mojang.com/api/jql-search-post` API

While the request format is a bit unusual (it being a `POST` request with some JQL syntax), the response format seems very similar to the old rest API. The only difference is that the `reporter` field is no longer (or not yet) exposed.

![image](https://github.com/user-attachments/assets/9fce13d1-c329-494a-97cb-27bcdff6062c)

## Discussion
* Now that this command is directly linked to the specific `bugs.mojang.com` command, it might be worth renaming the command
* Do we need/want to support other jira instances? Is this even feasible now that Jira Server is no more?